### PR TITLE
Primitive falsy values should not always be casted to null

### DIFF
--- a/example/Person.php
+++ b/example/Person.php
@@ -12,16 +12,19 @@ class Person implements CompositeValueObject
     private Age $age;
     private Address $address;
     private ?Phone $phone;
+    private bool $flag;
 
     public function __construct(
         Name $name,
         Age $age,
         Address $address,
+        bool $flag,
         ?Phone $phone = null
     ) {
         $this->name = $name;
         $this->age = $age;
         $this->address = $address;
+        $this->flag = $flag;
         $this->phone = $phone;
     }
 
@@ -38,6 +41,11 @@ class Person implements CompositeValueObject
     public function getAddress(): Address
     {
         return $this->address;
+    }
+
+    public function isFlag(): bool
+    {
+        return $this->flag;
     }
 
     public function getPhone(): ?Phone

--- a/src/Converter/CompositeValueObjectConverter.php
+++ b/src/Converter/CompositeValueObjectConverter.php
@@ -95,7 +95,7 @@ class CompositeValueObjectConverter implements ValueObjectConverter, SerializerA
 
             $args[] = $value
                 ? $this->serializer->hydrate($typeAsString, $value, false)
-                : null;
+                : $value;
         }
 
         /**

--- a/tests/DefaultSerializerTest.php
+++ b/tests/DefaultSerializerTest.php
@@ -63,6 +63,8 @@ class DefaultSerializerTest extends TestCase
     {
         yield 'age' => [new Age(42), 42];
 
+        yield 'age_falsy' => [new Age(0), 0];
+
         yield 'name' => [new Name('John Smith'), 'John Smith'];
 
         yield 'address' => [new Address('Broadway st', 'New York'), ['street' => 'Broadway st', 'city' => 'New York']];
@@ -79,6 +81,7 @@ class DefaultSerializerTest extends TestCase
                 new Name('John Smith'),
                 new Age(33),
                 new Address('Hollywood Square', 'Los Angeles'),
+                false,
                 new Phone('+391234567890')
             ),
             [
@@ -88,7 +91,8 @@ class DefaultSerializerTest extends TestCase
                     'street' => 'Hollywood Square',
                     'city' => 'Los Angeles'
                 ],
-                'phone' => '+391234567890'
+                'phone' => '+391234567890',
+                'flag' => false
             ]
         ];
     }


### PR DESCRIPTION
Signed-off-by: Emanuele Menon <emanuele.menon@facile.it>