### PR TITLE
Allows Converter for all objects types

### DIFF
--- a/src/Converter/ValueObjectConverter.php
+++ b/src/Converter/ValueObjectConverter.php
@@ -23,10 +23,9 @@ interface ValueObjectConverter
      * @param class-string $targetClass
      * @param mixed $value
      *
-     * @return ValueObject
-     * @phpstan-return T
+     * @return mixed
      */
-    public function hydrate(string $targetClass, $value): ValueObject;
+    public function hydrate(string $targetClass, $value);
 
     /**
      * @param object|string $object


### PR DESCRIPTION
Changed hydrate method signature in the Converter Interface to allow implementations related to also to object not subtype of ValueObject.

Signed-off-by: Emanuele Menon <emanuele.menon@facile.it>