### PR TITLE
add SerializerOptions interface

### DIFF
--- a/src/Contract/ValueObjectSerializer.php
+++ b/src/Contract/ValueObjectSerializer.php
@@ -2,6 +2,8 @@
 
 namespace CNastasi\Serializer\Contract;
 
+use CNastasi\Serializer\SerializerOptions;
+
 interface ValueObjectSerializer
 {
     /**
@@ -20,4 +22,6 @@ interface ValueObjectSerializer
      * @return mixed
      */
     public function hydrate(string $targetClass, $value, bool $isRoot = true);
+
+    public function getOptions(): SerializerOptions;
 }

--- a/src/Converter/CompositeValueObjectConverter.php
+++ b/src/Converter/CompositeValueObjectConverter.php
@@ -52,10 +52,18 @@ class CompositeValueObjectConverter implements ValueObjectConverter, SerializerA
             $name = $property->getName();
             $value = $this->getValue($object, $property);
 
-            $data[$name] = $this->serializer->serialize($value, false);
+            $serializedValue = $this->serializer->serialize($value, false);
+            if ($this->shouldAddAttribute($serializedValue)) {
+                $data[$name] = $serializedValue;
+            }
         }
 
         return $data;
+    }
+
+    private function shouldAddAttribute($value)
+    {
+        return null !== $value || false === $this->serializer->getOptions()->isIgnoreNull();
     }
 
     /**

--- a/src/DefaultSerializer.php
+++ b/src/DefaultSerializer.php
@@ -22,12 +22,15 @@ class DefaultSerializer implements ValueObjectSerializer
 
     private SerializationLoopGuard $loopGuard;
 
+    private SerializerOptionsDefault $options;
+
     /**
      * @phpunit-param array<mixed> $converters
      * @param array<mixed> $converters
      * @param SerializationLoopGuard $loopGuard
+     * @param SerializerOptions $options
      */
-    public function __construct(array $converters, SerializationLoopGuard $loopGuard)
+    public function __construct(array $converters, SerializationLoopGuard $loopGuard, SerializerOptions $options)
     {
         $this->loopGuard = $loopGuard;
 
@@ -36,6 +39,7 @@ class DefaultSerializer implements ValueObjectSerializer
         }
 
         $this->loopGuard = $loopGuard;
+        $this->options = $options;
     }
 
     public function serialize($object, bool $isRoot = true)
@@ -90,4 +94,10 @@ class DefaultSerializer implements ValueObjectSerializer
 
         $this->converters[] = $converter;
     }
+
+    public function getOptions(): SerializerOptions
+    {
+        return $this->options;
+    }
+
 }

--- a/src/SerializerOptions.php
+++ b/src/SerializerOptions.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace CNastasi\Serializer;
+
+interface SerializerOptions
+{
+    public function isIgnoreNull(): bool;
+}

--- a/src/SerializerOptionsDefault.php
+++ b/src/SerializerOptionsDefault.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace CNastasi\Serializer;
+
+
+class SerializerOptionsDefault implements SerializerOptions
+{
+
+    private bool $ignoreNull;
+
+    /**
+     * SerializerOptions constructor.
+     * @param bool $ignoreNull if true exclude property from serialization when the value is null
+     */
+    public function __construct(bool $ignoreNull)
+    {
+        $this->ignoreNull = $ignoreNull;
+    }
+
+    public function isIgnoreNull(): bool
+    {
+        return $this->ignoreNull;
+    }
+}

--- a/tests/DefaultSerializerIgnoreNullFalseTest.php
+++ b/tests/DefaultSerializerIgnoreNullFalseTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \CNastasi\Serializer\DefaultSerializer
  */
-class DefaultSerializerTest extends TestCase
+class DefaultSerializerIgnoreNullFalseTest extends TestCase
 {
 
     private DefaultSerializer $serializer;
@@ -65,21 +65,6 @@ class DefaultSerializerTest extends TestCase
      */
     public function dataProvider(): iterable
     {
-        yield 'age' => [new Age(42), 42];
-
-        yield 'age_falsy' => [new Age(0), 0];
-
-        yield 'name' => [new Name('John Smith'), 'John Smith'];
-
-        yield 'address' => [new Address('Broadway st', 'New York'), ['street' => 'Broadway st', 'city' => 'New York']];
-
-        yield 'classroom' => [
-            new Classroom(
-                [new Name('John Smith'), new Name('Lenny Brown'), new Name('Martha White')]
-            ),
-            ['John Smith', 'Lenny Brown', 'Martha White']
-        ];
-
         yield 'person' => [
             new Person(
                 new Name('John Smith'),
@@ -87,7 +72,7 @@ class DefaultSerializerTest extends TestCase
                 new Address('Hollywood Square', 'Los Angeles'),
                 new DateTimeImmutable('2020-10-12T08:53:08+00:00'),
                 false,
-                new Phone('+391234567890')
+                null
             ),
             [
                 'name' => 'John Smith',
@@ -96,7 +81,7 @@ class DefaultSerializerTest extends TestCase
                     'street' => 'Hollywood Square',
                     'city' => 'Los Angeles'
                 ],
-                'phone' => '+391234567890',
+                'phone' => null,
                 'flag' => false,
                 'birthDate' => '2020-10-12T08:53:08+00:00',
             ]

--- a/tests/DefaultSerializerIgnoreNullTrueTest.php
+++ b/tests/DefaultSerializerIgnoreNullTrueTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \CNastasi\Serializer\DefaultSerializer
  */
-class DefaultSerializerTest extends TestCase
+class DefaultSerializerIgnoreNullTrueTest extends TestCase
 {
 
     private DefaultSerializer $serializer;
@@ -41,7 +41,7 @@ class DefaultSerializerTest extends TestCase
                 new CollectionConverter()
             ],
             new SerializationLoopGuard(),
-            new SerializerOptionsDefault(false)
+            new SerializerOptionsDefault(true)
         );
     }
 
@@ -65,21 +65,6 @@ class DefaultSerializerTest extends TestCase
      */
     public function dataProvider(): iterable
     {
-        yield 'age' => [new Age(42), 42];
-
-        yield 'age_falsy' => [new Age(0), 0];
-
-        yield 'name' => [new Name('John Smith'), 'John Smith'];
-
-        yield 'address' => [new Address('Broadway st', 'New York'), ['street' => 'Broadway st', 'city' => 'New York']];
-
-        yield 'classroom' => [
-            new Classroom(
-                [new Name('John Smith'), new Name('Lenny Brown'), new Name('Martha White')]
-            ),
-            ['John Smith', 'Lenny Brown', 'Martha White']
-        ];
-
         yield 'person' => [
             new Person(
                 new Name('John Smith'),
@@ -87,7 +72,7 @@ class DefaultSerializerTest extends TestCase
                 new Address('Hollywood Square', 'Los Angeles'),
                 new DateTimeImmutable('2020-10-12T08:53:08+00:00'),
                 false,
-                new Phone('+391234567890')
+                null
             ),
             [
                 'name' => 'John Smith',
@@ -96,7 +81,6 @@ class DefaultSerializerTest extends TestCase
                     'street' => 'Hollywood Square',
                     'city' => 'Los Angeles'
                 ],
-                'phone' => '+391234567890',
                 'flag' => false,
                 'birthDate' => '2020-10-12T08:53:08+00:00',
             ]


### PR DESCRIPTION
The SerializerOptions interface allows you to create classes with specific options that can change the behavior of the serializer.
Currently the only class available is SerializerOptionsDefault, which allows you to exclude NULL properties from serialization.